### PR TITLE
5.15.x migrations: gstreamer 1.21, pulseaudio 16.1

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-11
   strategy:
     matrix:
       osx_64_:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,47 +14,30 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: C:\bld\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
-    - script: |
-        choco install vcpython27 -fdv -y --debug
-      condition: contains(variables['CONFIG'], 'vs2008')
-      displayName: Install vcpython27.msi (if needed)
-
-    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
-    # - script: rmdir C:\cygwin /s /q
-    #   continueOnError: true
-
-    - powershell: |
-        Set-PSDebug -Trace 1
-
-        $batchcontent = @"
-        ECHO ON
-        SET vcpython=C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0
-
-        DIR "%vcpython%"
-
-        CALL "%vcpython%\vcvarsall.bat" %*
-        "@
-
-        $batchDir = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC"
-        $batchPath = "$batchDir" + "\vcvarsall.bat"
-        New-Item -Path $batchPath -ItemType "file" -Force
-
-        Set-Content -Value $batchcontent -Path $batchPath
-
-        Get-ChildItem -Path $batchDir
-
-        Get-ChildItem -Path ($batchDir + '\..')
-
-      condition: contains(variables['CONFIG'], 'vs2008')
-      displayName: Patch vs2008 (if needed)
-    - task: CondaEnvironment@1
+    - task: PythonScript@0
+      displayName: 'Download Miniforge'
       inputs:
-        packageSpecs: 'python=3.9 conda-build conda pip boa conda-forge-ci-setup=3' # Optional
-        installOptions: "-c conda-forge"
-        updateConda: true
-      displayName: Install conda-build and activate environment
+        scriptSource: inline
+        script: |
+          import urllib.request
+          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Windows-x86_64.exe'
+          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
+          urllib.request.urlretrieve(url, path)
+
+    - script: |
+        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
+      displayName: Install Miniforge
+
+    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
+      displayName: Add conda to PATH
+
+    - script: |
+        call activate base
+        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
+      displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
       displayName: Set PYTHONUNBUFFERED
@@ -71,25 +54,16 @@ jobs:
         call activate base
         run_conda_forge_build_setup
       displayName: conda-forge build setup
-    
-
-    # Special cased version setting some more things!
-    - script: |
-        call activate base
-        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
-      displayName: Build recipe (vs2008)
-      env:
-        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
-        PYTHONUNBUFFERED: 1
-      condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
         call activate base
+        if EXIST LICENSE.txt (
+          copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
+        )
         conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1
-      condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
@@ -99,6 +73,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dbus:
 - '1'
 docker_image:
@@ -19,54 +19,31 @@ docker_image:
 expat:
 - '2'
 fontconfig:
-- '2.13'
+- '2'
 freetype:
 - '2'
 gst_plugins_base:
-- '1.20'
+- '1.21'
 gstreamer:
-- '1.20'
+- '1.21'
 libevent:
 - 2.1.10
 libiconv:
-- '1.16'
+- '1'
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 libwebp:
 - '1'
 libxml2:
-- '2.9'
+- '2.10'
 nspr:
 - '4'
 nss:
 - '3'
-pin_run_as_build:
-  dbus:
-    max_pin: x
-  fontconfig:
-    max_pin: x
-  freetype:
-    max_pin: x
-  libevent:
-    max_pin: x.x.x
-  libiconv:
-    max_pin: x.x
-  libpng:
-    max_pin: x.x
-  libxml2:
-    max_pin: x.x
-  nspr:
-    max_pin: x
-  nss:
-    max_pin: x
-  sqlite:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 pulseaudio:
-- '14.0'
-sqlite:
-- '3'
+- '16.1'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dbus:
 - '1'
 docker_image:
@@ -23,54 +23,31 @@ docker_image:
 expat:
 - '2'
 fontconfig:
-- '2.13'
+- '2'
 freetype:
 - '2'
 gst_plugins_base:
-- '1.20'
+- '1.21'
 gstreamer:
-- '1.20'
+- '1.21'
 libevent:
 - 2.1.10
 libiconv:
-- '1.16'
+- '1'
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 libwebp:
 - '1'
 libxml2:
-- '2.9'
+- '2.10'
 nspr:
 - '4'
 nss:
 - '3'
-pin_run_as_build:
-  dbus:
-    max_pin: x
-  fontconfig:
-    max_pin: x
-  freetype:
-    max_pin: x
-  libevent:
-    max_pin: x.x.x
-  libiconv:
-    max_pin: x.x
-  libpng:
-    max_pin: x.x
-  libxml2:
-    max_pin: x.x
-  nspr:
-    max_pin: x
-  nss:
-    max_pin: x
-  sqlite:
-    max_pin: x
-  zlib:
-    max_pin: x.x
 pulseaudio:
-- '14.0'
-sqlite:
-- '3'
+- '16.1'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/migrations/gstreamer121.yaml
+++ b/.ci_support/migrations/gstreamer121.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+gstreamer:
+- '1.21'
+gst_plugins_base:
+- '1.21'
+migrator_ts: 1664900131.838455

--- a/.ci_support/migrations/icu70.yaml
+++ b/.ci_support/migrations/icu70.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-icu:
-- '70'
-migrator_ts: 1648069834.8412466

--- a/.ci_support/migrations/pulseaudio161.yaml
+++ b/.ci_support/migrations/pulseaudio161.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1666923582.5704765
+pulseaudio:
+- '16.1'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,15 +13,17 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '14'
 gst_plugins_base:
-- '1.20'
+- '1.21'
 gstreamer:
-- '1.20'
+- '1.21'
 libiconv:
-- '1.16'
+- '1'
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 libwebp:
 - '1'
 macos_machine:
@@ -29,21 +31,6 @@ macos_machine:
 nspr:
 - '4'
 nss:
-- '3'
-pin_run_as_build:
-  libiconv:
-    max_pin: x.x
-  libpng:
-    max_pin: x.x
-  nspr:
-    max_pin: x
-  nss:
-    max_pin: x
-  sqlite:
-    max_pin: x
-  zlib:
-    max_pin: x.x
-sqlite:
 - '3'
 target_platform:
 - osx-64

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '13'
+- '14'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,15 +11,17 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '13'
+- '14'
 gst_plugins_base:
-- '1.20'
+- '1.21'
 gstreamer:
-- '1.20'
+- '1.21'
 libiconv:
-- '1.16'
+- '1'
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 libwebp:
 - '1'
 macos_machine:
@@ -27,21 +29,6 @@ macos_machine:
 nspr:
 - '4'
 nss:
-- '3'
-pin_run_as_build:
-  libiconv:
-    max_pin: x.x
-  libpng:
-    max_pin: x.x
-  nspr:
-    max_pin: x
-  nss:
-    max_pin: x
-  sqlite:
-    max_pin: x
-  zlib:
-    max_pin: x.x
-sqlite:
 - '3'
 target_platform:
 - osx-arm64

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,34 +1,25 @@
 c_compiler:
-- vs2017
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2017
+- vs2019
 gst_plugins_base:
-- '1.20'
+- '1.21'
 gstreamer:
-- '1.20'
+- '1.21'
 libiconv:
-- '1.16'
+- '1'
 libpng:
 - '1.6'
+libsqlite:
+- '3'
 libwebp:
 - '1'
 openssl:
 - 1.1.1
-pin_run_as_build:
-  libiconv:
-    max_pin: x.x
-  libpng:
-    max_pin: x.x
-  sqlite:
-    max_pin: x
-  zlib:
-    max_pin: x.x
-sqlite:
-- '3'
 target_platform:
 - win-64
 zlib:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,14 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,15 +24,18 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -48,6 +51,10 @@ fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,11 +23,10 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
-echo -e "\n\nInstalling ['conda-forge-ci-setup=3'] and conda-build."
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 
 
@@ -60,6 +59,10 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
+
+if [[ -f LICENSE.txt ]]; then
+  cp LICENSE.txt "recipe/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/README.md
+++ b/README.md
@@ -38,35 +38,35 @@ Current build status
               <td>linux_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15313&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=linux&configuration=linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15313&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=linux&configuration=linux_aarch64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15313&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=osx&configuration=osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15313&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=osx&configuration=osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>win_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15313&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=win&configuration=win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qt-webengine-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -45,7 +45,6 @@ if [[ $(uname) == "Linux" ]]; then
         PKG_CONFIG_EXECUTABLE=$(which pkg-config) \
         ..
 
-    # sed -i "/absl/base.internal.raw_logging.h/d" src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/internal/stacktrace_x86-inl.inc
     # Cleanup before final version
     # https://github.com/conda-forge/qt-webengine-feedstock/pull/15#issuecomment-1336593298
     pushd "${PREFIX}/lib"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ source:
       #    reverts
       # https://github.com/qt/qtwebengine-chromium/commit/b2de8e8046dc1c558465f74b4afe11d57cbc6cf3
       - patches/0011-revert_fp16_cast_syntax_change.patch
+      - patches/clang14-fixes.patch
 
   - url: https://download.qt.io/development_releases/gnuwin32/gnuwin32.zip  # [win]
     folder: gnuwin32  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ source:
       # https://github.com/qt/qtwebengine-chromium/commit/b2de8e8046dc1c558465f74b4afe11d57cbc6cf3
       - patches/0011-revert_fp16_cast_syntax_change.patch
       - patches/clang14-fixes.patch
+      # https://github.com/Homebrew/homebrew-core/pull/114739/files
+      - patches/qt5-webengine-xcode14.diff
 
   - url: https://download.qt.io/development_releases/gnuwin32/gnuwin32.zip  # [win]
     folder: gnuwin32  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,18 +7,26 @@ package:
   version: {{ version }}
 
 source:
-  - git_url: https://code.qt.io/qt/qtwebengine.git
-    git_rev: v{{ version }}-lts
-
-  - git_url: https://code.qt.io/qt/qtwebengine-chromium.git
-    git_rev: 87-based
-    folder: qtwebengine-chromium
+  - url: https://download.qt.io/official_releases/qt/{{ version_major_minor }}/{{ version }}/submodules/qtwebengine-everywhere-opensource-src-{{ version }}.tar.xz
+    sha256: 8a2a903bcf2c45d8981f90fdfe96a9413d6fcfa0510e45c407a41a9b6bda0fca
     patches:
       - patches/0001-aarch64-sys-state-structs.patch                             # [aarch64]
       - patches/0002-macos-fatal-warnings.patch                                  # [osx]
       - patches/0003-Set-host-and-target-cpus-in-gn-build.patch                  # [arm64]
       - patches/0005-macos-use-CONDA_BUILD_SYSROOT.patch                         # [osx]
       - patches/0007-Compile-GN-to-support-both-x86_64-and-arm64-archs-wh.patch  # [arm64]
+      # https://bugreports.qt.io/browse/QTBUG-101995?focusedCommentId=653798
+      # https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/402639
+      - patches/fix_unused_var_in_harfbuzz_ng.patch
+      # This patch may be required for other OSes too
+      # similar to the discussion in
+      # https://github.com/abseil/abseil-cpp/issues/1275
+      - patches/limits_h_header.patch
+      # Only used in aarch64 / osx-arm
+      # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=236855#c8
+      #    reverts
+      # https://github.com/qt/qtwebengine-chromium/commit/b2de8e8046dc1c558465f74b4afe11d57cbc6cf3
+      - patches/0011-revert_fp16_cast_syntax_change.patch
 
   - url: https://download.qt.io/development_releases/gnuwin32/gnuwin32.zip  # [win]
     folder: gnuwin32  # [win]
@@ -78,6 +86,7 @@ requirements:
     - {{ cdt('cups-devel') }}            # [linux]
     - {{ cdt('libxcb') }}                # [linux]
     - {{ cdt('expat-devel') }}           # [linux]
+    - {{ cdt('pcre') }}                  # [linux]
     - pkg-config                         # [unix]
     - make                               # [unix]
     - cmake
@@ -114,11 +123,10 @@ requirements:
     - libiconv
     - nspr                               # [unix]
     - nss                                # [unix]
-    - sqlite
+    - libsqlite
     - zlib
     - libxcb                             # [linux]
-    # Matches the other migrations that we care for this feedstock
-    - qt-main    5.15.3
+    - qt-main
     - libwebp
     - openssl                            # [win]
   run:
@@ -128,7 +136,7 @@ requirements:
     # As of, 2022/04/25, Qt 5.15.4 was only ever released to commercial
     # users. However it seems that qt webengine 5.15.4 sources were
     # released
-    - qt 5.15.3|5.15.4
+    - qt 5.15.3|5.15.4|5.15.6
     # - qt {{ version }}
 
 test:

--- a/recipe/patches/0001-aarch64-sys-state-structs.patch
+++ b/recipe/patches/0001-aarch64-sys-state-structs.patch
@@ -1,7 +1,7 @@
-diff --git a/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h b/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h
+diff --git a/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h b/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h
 index fb216fa6d71..4f957e54c39 100644
---- a/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h
-+++ b/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h
+--- a/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h
++++ b/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h
 @@ -66,8 +66,8 @@ struct ThreadInfo {
    struct user_fpregs fpregs;
  #elif defined(__aarch64__)
@@ -13,10 +13,10 @@ index fb216fa6d71..4f957e54c39 100644
  #elif defined(__mips__)
    // Use the structure defined in <sys/ucontext.h>.
    mcontext_t mcontext;
-diff --git a/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc b/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc
+diff --git a/src/3rdparty/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc b/src/3rdparty/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc
 index aade82c996d..fa7df048e5d 100644
---- a/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc
-+++ b/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc
+--- a/src/3rdparty/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc
++++ b/src/3rdparty/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc
 @@ -320,7 +320,7 @@ struct CrashedProcess {
      user_fpxregs_struct fpxregs;
  #endif

--- a/recipe/patches/0002-macos-fatal-warnings.patch
+++ b/recipe/patches/0002-macos-fatal-warnings.patch
@@ -1,7 +1,7 @@
-diff --git a/chromium/build/config/compiler/BUILD.gn b/chromium/build/config/compiler/BUILD.gn
+diff --git a/src/3rdparty/chromium/build/config/compiler/BUILD.gn b/src/3rdparty/chromium/build/config/compiler/BUILD.gn
 index 6a58d21cf07..4cabf5237a3 100644
---- a/chromium/build/config/compiler/BUILD.gn
-+++ b/chromium/build/config/compiler/BUILD.gn
+--- a/src/3rdparty/chromium/build/config/compiler/BUILD.gn
++++ b/src/3rdparty/chromium/build/config/compiler/BUILD.gn
 @@ -64,7 +64,7 @@ declare_args() {
  
    # Enable fatal linker warnings. Building Chromium with certain versions

--- a/recipe/patches/0003-Set-host-and-target-cpus-in-gn-build.patch
+++ b/recipe/patches/0003-Set-host-and-target-cpus-in-gn-build.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Set host and target cpus in gn build
  chromium/build/config/BUILDCONFIG.gn | 9 +++++++++
  1 file changed, 9 insertions(+)
 
-diff --git a/chromium/build/config/BUILDCONFIG.gn b/chromium/build/config/BUILDCONFIG.gn
+diff --git a/src/3rdparty/chromium/build/config/BUILDCONFIG.gn b/src/3rdparty/chromium/build/config/BUILDCONFIG.gn
 index 3815dd6f941..04c7af0afc9 100644
---- a/chromium/build/config/BUILDCONFIG.gn
-+++ b/chromium/build/config/BUILDCONFIG.gn
+--- a/src/3rdparty/chromium/build/config/BUILDCONFIG.gn
++++ b/src/3rdparty/chromium/build/config/BUILDCONFIG.gn
 @@ -50,6 +50,14 @@ if (target_os == "") {
    target_os = host_os
  }

--- a/recipe/patches/0005-macos-use-CONDA_BUILD_SYSROOT.patch
+++ b/recipe/patches/0005-macos-use-CONDA_BUILD_SYSROOT.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Use CONDA_BUILD_SYSROOT
  gn/build/gen.py | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/gn/build/gen.py b/gn/build/gen.py
+diff --git a/src/3rdparty/gn/build/gen.py b/src/3rdparty/gn/build/gen.py
 index 8c646be8be3..2a37cb4e1ac 100755
---- a/gn/build/gen.py
-+++ b/gn/build/gen.py
+--- a/src/3rdparty/gn/build/gen.py
++++ b/src/3rdparty/gn/build/gen.py
 @@ -110,6 +110,7 @@ def main(argv):
                      help='The path to the macOS SDK sysroot to be used.')
    options, args = parser.parse_args(argv)

--- a/recipe/patches/0007-Compile-GN-to-support-both-x86_64-and-arm64-archs-wh.patch
+++ b/recipe/patches/0007-Compile-GN-to-support-both-x86_64-and-arm64-archs-wh.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Compile GN to support both x86_64 and arm64 archs when
  crosscompiling on MacOs
 
 ---
- gn/build/gen.py | 3 +++
+ src/3rdparty/gn/build/gen.py | 3 +++
  1 file changed, 3 insertions(+)
 
-diff --git a/gn/build/gen.py b/gn/build/gen.py
+diff --git a/src/3rdparty/gn/build/gen.py b/src/3rdparty/gn/build/gen.py
 index 2a37cb4e1ac..a23fac8befe 100755
---- a/gn/build/gen.py
-+++ b/gn/build/gen.py
+--- a/src/3rdparty/gn/build/gen.py
++++ b/src/3rdparty/gn/build/gen.py
 @@ -331,6 +331,9 @@ def WriteGNNinja(path, platform, host, options):
        ldflags.extend(['-fdata-sections', '-ffunction-sections'])
        if platform.is_darwin():

--- a/recipe/patches/0010-abseil-numeric-limits.patch
+++ b/recipe/patches/0010-abseil-numeric-limits.patch
@@ -1,0 +1,40 @@
+From 518984e432e0597fd4e66a9c52148e8dec2bb46a Mon Sep 17 00:00:00 2001
+From: Derek Mauro <dmauro@google.com>
+Date: Thu, 8 Sep 2022 08:07:13 -0700
+Subject: [PATCH] Fix stacktrace header includes
+
+Fixes #1275
+
+PiperOrigin-RevId: 472990940
+Change-Id: I1251b01b09e6a9baac52ae4df443714432115e90
+---
+ absl/debugging/internal/stacktrace_riscv-inl.inc | 2 ++
+ absl/debugging/internal/stacktrace_x86-inl.inc   | 2 --
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/internal/stacktrace_riscv-inl.inc b/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/internal/stacktrace_riscv-inl.inc
+index a9e2c323e7..20183fa321 100644
+--- a/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/internal/stacktrace_riscv-inl.inc
++++ b/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/internal/stacktrace_riscv-inl.inc
+@@ -30,6 +30,8 @@
+ #include <cassert>
+ #include <cstdint>
+ #include <iostream>
++#include <limits>
++#include <utility>
+ 
+ #include "absl/base/attributes.h"
+ #include "absl/debugging/stacktrace.h"
+diff --git a/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/internal/stacktrace_x86-inl.inc b/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/internal/stacktrace_x86-inl.inc
+index 1354cb3769..9fbfcf767a 100644
+--- a/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/internal/stacktrace_x86-inl.inc
++++ b/src/3rdparty/chromium/third_party/abseil-cpp/absl/debugging/internal/stacktrace_x86-inl.inc
+@@ -35,8 +35,6 @@
+ #include "absl/debugging/internal/vdso_support.h"  // a no-op on non-elf or non-glibc systems
+ #include "absl/debugging/stacktrace.h"
+ 
+-#include "absl/base/internal/raw_logging.h"
+-
+ using absl::debugging_internal::AddressIsReadable;
+ 
+ #if defined(__linux__) && defined(__i386__)

--- a/recipe/patches/0011-revert_fp16_cast_syntax_change.patch
+++ b/recipe/patches/0011-revert_fp16_cast_syntax_change.patch
@@ -1,0 +1,25 @@
+--- a/src/3rdparty/chromium/third_party/skia/src/opts/SkRasterPipeline_opts.h	2021-05-11 09:12:17.000000000 -0400
++++ b/src/3rdparty/chromium/third_party/skia/src/opts/SkRasterPipeline_opts.h	2022-12-05 10:40:13.977488268 -0500
+@@ -980,9 +980,7 @@
+ SI F from_half(U16 h) {
+ #if defined(JUMPER_IS_NEON) && defined(SK_CPU_ARM64) \
+     && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+-    __fp16 fp16;
+-    memcpy(&fp16, &h, sizeof(U16));
+-    return float(fp16);
++    return vcvt_f32_f16(h);
+ 
+ #elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_SKX)
+     return _mm256_cvtph_ps(h);
+@@ -1003,10 +1001,7 @@
+ SI U16 to_half(F f) {
+ #if defined(JUMPER_IS_NEON) && defined(SK_CPU_ARM64) \
+     && !defined(SK_BUILD_FOR_GOOGLE3)  // Temporary workaround for some Google3 builds.
+-    __fp16 fp16 = __fp16(f);
+-    U16 u16;
+-    memcpy(&u16, &fp16, sizeof(U16));
+-    return u16;
++    return vcvt_f16_f32(f);
+ 
+ #elif defined(JUMPER_IS_HSW) || defined(JUMPER_IS_SKX)
+     return _mm256_cvtps_ph(f, _MM_FROUND_CUR_DIRECTION);

--- a/recipe/patches/clang14-fixes.patch
+++ b/recipe/patches/clang14-fixes.patch
@@ -1,0 +1,18 @@
+From https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=261949
+
+--- src/3rdparty/chromium/third_party/blink/renderer/platform/text/text_break_iterator_icu.cc.orig	2020-11-07 01:22:36 UTC
++++ src/3rdparty/chromium/third_party/blink/renderer/platform/text/text_break_iterator_icu.cc
+@@ -119,11 +119,11 @@ enum TextContext { kNoContext, kPriorContext, kPrimary
+ 
+ const int kTextBufferCapacity = 16;
+ 
+-typedef struct {
++struct UTextWithBuffer {
+   DISALLOW_NEW();
+   UText text;
+   UChar buffer[kTextBufferCapacity];
+-} UTextWithBuffer;
++};
+ 
+ static inline int64_t TextPinIndex(int64_t& index, int64_t limit) {
+   if (index < 0)

--- a/recipe/patches/fix_unused_var_in_harfbuzz_ng.patch
+++ b/recipe/patches/fix_unused_var_in_harfbuzz_ng.patch
@@ -1,0 +1,43 @@
+From caaa9b1ff83c5b782143acc5d35bc1113c0c7c43 Mon Sep 17 00:00:00 2001
+From: Michal Klocek <michal.klocek@qt.io>
+Date: Fri, 25 Mar 2022 11:18:12 +0100
+Subject: [PATCH] Fix unused var in harfbuzz-ng
+
+Fixes: QTBUG-101995
+Change-Id: I0186ebf2eb8219796f7d901055f0037c0843e454
+---
+ chromium/third_party/harfbuzz-ng/src/src/hb-subset-cff1.cc | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/3rdparty/chromium/third_party/harfbuzz-ng/src/src/hb-subset-cff1.cc b/src/3rdparty/chromium/third_party/harfbuzz-ng/src/src/hb-subset-cff1.cc
+index df322f8451c..35dae7b1f11 100644
+--- a/src/3rdparty/chromium/third_party/harfbuzz-ng/src/src/hb-subset-cff1.cc
++++ b/src/3rdparty/chromium/third_party/harfbuzz-ng/src/src/hb-subset-cff1.cc
+@@ -402,7 +402,7 @@ struct cff_subset_plan {
+   void plan_subset_encoding (const OT::cff1::accelerator_subset_t &acc, hb_subset_plan_t *plan)
+   {
+     const Encoding *encoding = acc.encoding;
+-    unsigned int  size0, size1, supp_size;
++    unsigned int  size0, size1;
+     hb_codepoint_t  code, last_code = CFF_UNDEF_CODE;
+     hb_vector_t<hb_codepoint_t> supp_codes;
+ 
+@@ -412,7 +412,6 @@ struct cff_subset_plan {
+       return;
+     }
+ 
+-    supp_size = 0;
+     supp_codes.init ();
+ 
+     subset_enc_num_codes = plan->num_output_glyphs () - 1;
+@@ -448,7 +447,6 @@ struct cff_subset_plan {
+ 	  code_pair_t pair = { supp_codes[i], sid };
+ 	  subset_enc_supp_codes.push (pair);
+ 	}
+-	supp_size += SuppEncoding::static_size * supp_codes.length;
+       }
+     }
+     supp_codes.fini ();
+-- 
+2.16.3
+

--- a/recipe/patches/limits_h_header.patch
+++ b/recipe/patches/limits_h_header.patch
@@ -1,0 +1,20 @@
+--- a/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h	2021-05-11 09:12:17.000000000 -0400
++++ b/src/3rdparty/chromium/third_party/perfetto/src/trace_processor/containers/string_pool.h	2022-12-05 07:47:18.222892162 -0500
+@@ -20,6 +20,7 @@
+ #include <stddef.h>
+ #include <stdint.h>
+ 
++#include <limits>
+ #include <unordered_map>
+ #include <vector>
+ 
+--- a/src/3rdparty/chromium/third_party/abseil-cpp/absl/synchronization/internal/graphcycles.cc	2021-05-11 09:12:17.000000000 -0400
++++ b/src/3rdparty/chromium/third_party/abseil-cpp/absl/synchronization/internal/graphcycles.cc	2022-12-05 07:47:01.310925339 -0500
+@@ -35,6 +35,7 @@
+ 
+ #include "absl/synchronization/internal/graphcycles.h"
+ 
++#include <limits>
+ #include <algorithm>
+ #include <array>
+ #include "absl/base/internal/hide_ptr.h"

--- a/recipe/patches/qt5-webengine-xcode14.diff
+++ b/recipe/patches/qt5-webengine-xcode14.diff
@@ -1,0 +1,50 @@
+diff --git a/src/3rdparty/chromium/third_party/blink/renderer/core/editing/finder/text_finder.cc b/src/3rdparty/chromium/third_party/blink/renderer/core/editing/finder/text_finder.cc
+index e41a894fc28..85df6865cfe 100644
+--- a/src/3rdparty/chromium/third_party/blink/renderer/core/editing/finder/text_finder.cc
++++ b/src/3rdparty/chromium/third_party/blink/renderer/core/editing/finder/text_finder.cc
+@@ -629,7 +629,8 @@ gfx::RectF TextFinder::ActiveFindMatchRect() {
+   if (!current_active_match_frame_ || !active_match_)
+     return gfx::RectF();
+ 
+-  return gfx::RectF(FindInPageRectFromRange(EphemeralRange(ActiveMatch())));
++  FloatRect r = FindInPageRectFromRange(EphemeralRange(ActiveMatch()));
++  return gfx::RectF(r.X(), r.Y(), r.Width(), r.Height());
+ }
+ 
+ Vector<gfx::RectF> TextFinder::FindMatchRects() {
+@@ -639,7 +640,8 @@ Vector<gfx::RectF> TextFinder::FindMatchRects() {
+   match_rects.ReserveCapacity(match_rects.size() + find_matches_cache_.size());
+   for (const FindMatch& match : find_matches_cache_) {
+     DCHECK(!match.rect_.IsEmpty());
+-    match_rects.push_back(match.rect_);
++    FloatRect r = match.rect_;
++    match_rects.push_back(gfx::RectF(r.X(), r.Y(), r.Width(), r.Height()));
+   }
+ 
+   return match_rects;
+diff --git a/src/3rdparty/chromium/third_party/blink/renderer/core/paint/paint_timing_detector.cc b/src/3rdparty/chromium/third_party/blink/renderer/core/paint/paint_timing_detector.cc
+index 48d06120e0c..df357910406 100644
+--- a/src/3rdparty/chromium/third_party/blink/renderer/core/paint/paint_timing_detector.cc
++++ b/src/3rdparty/chromium/third_party/blink/renderer/core/paint/paint_timing_detector.cc
+@@ -320,7 +320,7 @@ FloatRect PaintTimingDetector::BlinkSpaceToDIPs(
+   // May be nullptr in tests.
+   if (!widget)
+     return float_rect;
+-  return FloatRect(widget->BlinkSpaceToDIPs(gfx::RectF(float_rect)));
++  return FloatRect(widget->BlinkSpaceToDIPs(gfx::RectF(float_rect.X(), float_rect.Y(), float_rect.Width(), float_rect.Height())));
+ }
+ 
+ FloatRect PaintTimingDetector::CalculateVisualRect(
+diff --git a/src/3rdparty/chromium/third_party/blink/renderer/modules/exported/web_ax_object.cc b/src/3rdparty/chromium/third_party/blink/renderer/modules/exported/web_ax_object.cc
+index f7a348c812e..06cd41f00be 100644
+--- a/src/3rdparty/chromium/third_party/blink/renderer/modules/exported/web_ax_object.cc
++++ b/src/3rdparty/chromium/third_party/blink/renderer/modules/exported/web_ax_object.cc
+@@ -1480,7 +1480,7 @@ void WebAXObject::GetRelativeBounds(WebAXObject& offset_container,
+   private_->GetRelativeBounds(&container, bounds, container_transform,
+                               clips_children);
+   offset_container = WebAXObject(container);
+-  bounds_in_container = gfx::RectF(bounds);
++  bounds_in_container = gfx::RectF(bounds.X(), bounds.Y(), bounds.Width(), bounds.Height());
+ }
+ 
+ void WebAXObject::GetAllObjectsWithChangedBounds(


### PR DESCRIPTION
- [x] Used archive as source
- [x] Ported patches over
- [x] linux 64 builds -- https://anaconda.org/mark.harfouche/qt-webengine/files
- [x] linux aarch 64 builds -- https://anaconda.org/mark.harfouche/qt-webengine/files
- [x] osx x86_64 builds -- uploaded directly to conda-forge
- [x] osx arm builds -- https://anaconda.org/tobiasrobotics/qt-webengine
- [x] windows x86_64 builds -- https://anaconda.org/pkgw-forge/qt-webengine/files/
- [x] pulseaudio 16


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
